### PR TITLE
Filtration: support pattern matching operators for text attributes #16

### DIFF
--- a/graphql/src/main/java/io/jmix/graphql/schema/FilterTypesBuilder.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/FilterTypesBuilder.java
@@ -61,6 +61,10 @@ public class FilterTypesBuilder extends BaseTypesBuilder {
                 .inputValueDefinition(valueDef("GTE", scalarTypeName, "greater than or equals"))
                 .inputValueDefinition(valueDef("LT", scalarTypeName, "less that"))
                 .inputValueDefinition(valueDef("LTE", scalarTypeName, "less than or equals"))
+                .inputValueDefinition(valueDef("_cont", scalarTypeName, "contains substring"))
+                .inputValueDefinition(valueDef("_ncont", scalarTypeName, "not contains substring"))
+                .inputValueDefinition(valueDef("_stw", scalarTypeName, "starts with substring"))
+                .inputValueDefinition(valueDef("_enw", scalarTypeName, "ends with substring"))
                 .build();
     }
 

--- a/graphql/src/main/java/io/jmix/graphql/schema/FilterTypesBuilder.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/FilterTypesBuilder.java
@@ -61,10 +61,10 @@ public class FilterTypesBuilder extends BaseTypesBuilder {
                 .inputValueDefinition(valueDef("GTE", scalarTypeName, "greater than or equals"))
                 .inputValueDefinition(valueDef("LT", scalarTypeName, "less that"))
                 .inputValueDefinition(valueDef("LTE", scalarTypeName, "less than or equals"))
-                .inputValueDefinition(valueDef("_cont", scalarTypeName, "contains substring"))
-                .inputValueDefinition(valueDef("_ncont", scalarTypeName, "not contains substring"))
-                .inputValueDefinition(valueDef("_stw", scalarTypeName, "starts with substring"))
-                .inputValueDefinition(valueDef("_enw", scalarTypeName, "ends with substring"))
+                .inputValueDefinition(valueDef("_contains", scalarTypeName, "contains substring"))
+                .inputValueDefinition(valueDef("_notContains", scalarTypeName, "not contains substring"))
+                .inputValueDefinition(valueDef("_startsWith", scalarTypeName, "starts with substring"))
+                .inputValueDefinition(valueDef("_endsWith", scalarTypeName, "ends with substring"))
                 .build();
     }
 

--- a/graphql/src/main/java/io/jmix/graphql/schema/Types.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/Types.java
@@ -25,10 +25,10 @@ public class Types {
         GTE(PropertyCondition.Operation.GREATER_OR_EQUAL),
         LT(PropertyCondition.Operation.LESS),
         LTE(PropertyCondition.Operation.LESS_OR_EQUAL),
-        _cont(PropertyCondition.Operation.CONTAINS),
-        _ncont(PropertyCondition.Operation.NOT_CONTAINS),
-        _stw(PropertyCondition.Operation.STARTS_WITH),
-        _enw(PropertyCondition.Operation.ENDS_WITH);
+        _contains(PropertyCondition.Operation.CONTAINS),
+        _notContains(PropertyCondition.Operation.NOT_CONTAINS),
+        _startsWith(PropertyCondition.Operation.STARTS_WITH),
+        _endsWith(PropertyCondition.Operation.ENDS_WITH);
 
         FilterOperation(String jmixOperation) {
             this.jmixOperation = jmixOperation;

--- a/graphql/src/main/java/io/jmix/graphql/schema/Types.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/Types.java
@@ -24,7 +24,11 @@ public class Types {
         GT(PropertyCondition.Operation.GREATER),
         GTE(PropertyCondition.Operation.GREATER_OR_EQUAL),
         LT(PropertyCondition.Operation.LESS),
-        LTE(PropertyCondition.Operation.LESS_OR_EQUAL);
+        LTE(PropertyCondition.Operation.LESS_OR_EQUAL),
+        _cont(PropertyCondition.Operation.CONTAINS),
+        _ncont(PropertyCondition.Operation.NOT_CONTAINS),
+        _stw(PropertyCondition.Operation.STARTS_WITH),
+        _enw(PropertyCondition.Operation.ENDS_WITH);
 
         FilterOperation(String jmixOperation) {
             this.jmixOperation = jmixOperation;


### PR DESCRIPTION
The next filter conditions were added:
_cont (contains)
_ncont (not contains)
_stw (starts with)
_enw (end with)