### PR TITLE
Filtration: support list based search operations (in, not in) #14

### DIFF
--- a/graphql/src/main/java/io/jmix/graphql/datafetcher/FilterConditionBuilder.java
+++ b/graphql/src/main/java/io/jmix/graphql/datafetcher/FilterConditionBuilder.java
@@ -15,6 +15,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static io.jmix.graphql.schema.Types.FilterOperation.IN_LIST;
+import static io.jmix.graphql.schema.Types.FilterOperation.NOT_IN_LIST;
+
 @Component
 public class FilterConditionBuilder {
 
@@ -47,13 +50,15 @@ public class FilterConditionBuilder {
             }
 
             String newPath = StringUtils.isEmpty(path) ? condPath : path + "." + condPath;
-            if (Collection.class.isAssignableFrom(condition.getClass())) {
+            if (Collection.class.isAssignableFrom(condition.getClass())
+                    && !IN_LIST.getId().equals(condPath)
+                    && !NOT_IN_LIST.getId().equals(condPath)) {
                 result.addAll(buildCollectionOfConditions(newPath, (Collection<Map<String, Object>>) condition));
                 return;
             }
 
             log.debug("buildPropertyCondition: {} {} {}", path, condPath, condition);
-            Types.FilterOperation operation = Types.FilterOperation.valueOf(condPath);
+            Types.FilterOperation operation = Types.FilterOperation.fromId(condPath);
             result.add(PropertyCondition.createWithValue(path, operation.getJmixOperation(), condition));
         });
         return result;

--- a/graphql/src/main/java/io/jmix/graphql/schema/FilterTypesBuilder.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/FilterTypesBuilder.java
@@ -1,6 +1,8 @@
 package io.jmix.graphql.schema;
 
-import graphql.language.*;
+import graphql.language.Comment;
+import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputValueDefinition;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import org.slf4j.Logger;
@@ -15,6 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static io.jmix.graphql.schema.Types.FilterOperation.*;
 import static io.jmix.graphql.schema.Types.listValueDef;
 import static io.jmix.graphql.schema.Types.valueDef;
 
@@ -55,16 +58,18 @@ public class FilterTypesBuilder extends BaseTypesBuilder {
         return InputObjectTypeDefinition.newInputObjectDefinition()
                 .name(name)
                 .comments(Collections.singletonList(new Comment(comment, null)))
-                .inputValueDefinition(valueDef("EQ", scalarTypeName, "equals"))
-                .inputValueDefinition(valueDef("NEQ", scalarTypeName, "not equals"))
-                .inputValueDefinition(valueDef("GT", scalarTypeName, "greater than"))
-                .inputValueDefinition(valueDef("GTE", scalarTypeName, "greater than or equals"))
-                .inputValueDefinition(valueDef("LT", scalarTypeName, "less that"))
-                .inputValueDefinition(valueDef("LTE", scalarTypeName, "less than or equals"))
-                .inputValueDefinition(valueDef("_contains", scalarTypeName, "contains substring"))
-                .inputValueDefinition(valueDef("_notContains", scalarTypeName, "not contains substring"))
-                .inputValueDefinition(valueDef("_startsWith", scalarTypeName, "starts with substring"))
-                .inputValueDefinition(valueDef("_endsWith", scalarTypeName, "ends with substring"))
+                .inputValueDefinition(valueDef(EQ.getId(), scalarTypeName, "equals"))
+                .inputValueDefinition(valueDef(NEQ.getId(), scalarTypeName, "not equals"))
+                .inputValueDefinition(valueDef(GT.getId(), scalarTypeName, "greater than"))
+                .inputValueDefinition(valueDef(GTE.getId(), scalarTypeName, "greater than or equals"))
+                .inputValueDefinition(valueDef(LT.getId(), scalarTypeName, "less that"))
+                .inputValueDefinition(valueDef(LTE.getId(), scalarTypeName, "less than or equals"))
+                .inputValueDefinition(valueDef(CONTAINS.getId(), scalarTypeName, "contains substring"))
+                .inputValueDefinition(valueDef(NOT_CONTAINS.getId(), scalarTypeName, "not contains substring"))
+                .inputValueDefinition(valueDef(STARTS_WITH.getId(), scalarTypeName, "starts with substring"))
+                .inputValueDefinition(valueDef(ENDS_WITH.getId(), scalarTypeName, "ends with substring"))
+                .inputValueDefinition(listValueDef(IN_LIST.getId(), scalarTypeName, "in list"))
+                .inputValueDefinition(listValueDef(NOT_IN_LIST.getId(), scalarTypeName, "not in list"))
                 .build();
     }
 

--- a/graphql/src/main/java/io/jmix/graphql/schema/Types.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/Types.java
@@ -19,27 +19,47 @@ public class Types {
     }
 
     public enum FilterOperation {
-        EQ(PropertyCondition.Operation.EQUAL),
-        NEQ(PropertyCondition.Operation.NOT_EQUAL),
-        GT(PropertyCondition.Operation.GREATER),
-        GTE(PropertyCondition.Operation.GREATER_OR_EQUAL),
-        LT(PropertyCondition.Operation.LESS),
-        LTE(PropertyCondition.Operation.LESS_OR_EQUAL),
-        _contains(PropertyCondition.Operation.CONTAINS),
-        _notContains(PropertyCondition.Operation.NOT_CONTAINS),
-        _startsWith(PropertyCondition.Operation.STARTS_WITH),
-        _endsWith(PropertyCondition.Operation.ENDS_WITH);
+        EQ("EQ", PropertyCondition.Operation.EQUAL),
+        NEQ("NEQ", PropertyCondition.Operation.NOT_EQUAL),
+        GT("GT", PropertyCondition.Operation.GREATER),
+        GTE("GTE", PropertyCondition.Operation.GREATER_OR_EQUAL),
+        LT("LT", PropertyCondition.Operation.LESS),
+        LTE("LTE", PropertyCondition.Operation.LESS_OR_EQUAL),
+        CONTAINS("_contains", PropertyCondition.Operation.CONTAINS),
+        NOT_CONTAINS("_notContains", PropertyCondition.Operation.NOT_CONTAINS),
+        STARTS_WITH("_startsWith", PropertyCondition.Operation.STARTS_WITH),
+        ENDS_WITH("_endsWith", PropertyCondition.Operation.ENDS_WITH),
+        IN_LIST("_inList", PropertyCondition.Operation.IN_LIST),
+        NOT_IN_LIST("_notInList", PropertyCondition.Operation.NOT_IN_LIST);
 
-        FilterOperation(String jmixOperation) {
+        private final String id;
+        private final String jmixOperation;
+
+        FilterOperation(String id, String jmixOperation) {
+            this.id = id;
             this.jmixOperation = jmixOperation;
         }
 
-        private final String jmixOperation;
+        public static FilterOperation fromId(String id) {
+            if (id != null) {
+                for (FilterOperation operation :
+                        FilterOperation.values()) {
+                    if (operation.getId().equals(id)) {
+                        return operation;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public String getId() {
+            return id;
+        }
 
         public String getJmixOperation() {
             return jmixOperation;
         }
-
     }
 
     public static GraphQLScalarType[] scalars = {

--- a/graphql/src/main/java/io/jmix/graphql/schema/Types.java
+++ b/graphql/src/main/java/io/jmix/graphql/schema/Types.java
@@ -29,8 +29,8 @@ public class Types {
         NOT_CONTAINS("_notContains", PropertyCondition.Operation.NOT_CONTAINS),
         STARTS_WITH("_startsWith", PropertyCondition.Operation.STARTS_WITH),
         ENDS_WITH("_endsWith", PropertyCondition.Operation.ENDS_WITH),
-        IN_LIST("_inList", PropertyCondition.Operation.IN_LIST),
-        NOT_IN_LIST("_notInList", PropertyCondition.Operation.NOT_IN_LIST);
+        IN_LIST("_in", PropertyCondition.Operation.IN_LIST),
+        NOT_IN_LIST("_notIn", PropertyCondition.Operation.NOT_IN_LIST);
 
         private final String id;
         private final String jmixOperation;


### PR DESCRIPTION
FilterOperation enum was refactored and added list operations. It has an id now which allows using it in FilterTypesBuilder and refactoring in the future will be easier